### PR TITLE
docs: add repository link to the documentation navbar

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,11 @@
 site_name: VideoMaker-Helper
+repo_url: https://github.com/dunossauro/videomaker-helper
+repo_name: videomaker-helper
 
 theme:
   name: material
-
+  icon:
+    repo: fontawesome/brands/git-alt
 plugins:
   - mkdocs-video:
       is_video: True


### PR DESCRIPTION
Add repository link to the documentation navbar
[Issue  #20 Add repo on doc](https://github.com/dunossauro/videomaker-helper/issues/20)

![image](https://github.com/user-attachments/assets/214d0242-2ecc-4e6b-aacf-90348120ca92)
